### PR TITLE
Initiate a simple CI and README.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: Netifly_Deployment
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches: 
-      - main
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Netifly_Deployment
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: 
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: './'
+          deploy-message: "Deploy from GitHub Actions"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+
+<p align="center" width="100">
+  <img src="/static/images/mir_logo.png" width="150" alt="MiR Community logo">
+</p>
+
+# MiR Community Website
+
+URL: https://mircommunity.com/ 


### PR DESCRIPTION
This is just a very simple CI to preview Netifly Deployment in GitHub before merging. it makes it easier to experiment with the website and observe the changes before making it live. However, someone needs to add both `${{ secrets.NETLIFY_AUTH_TOKEN }}` and `${{ secrets.NETLIFY_SITE_ID }}` in the setting. I also added an extremely simple README with the website URL and the logo. This is because it wasn't easy for me to find the website. 